### PR TITLE
fixed app crashes when device rotated and photos stays selected even after rotating screen.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
     android:supportsRtl="true"
     android:theme="@style/AppTheme">
 
-    <activity android:name=".ui.MainActivity">
+    <activity android:name=".ui.MainActivity"
+        android:configChanges="orientation|screenSize">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
 


### PR DESCRIPTION
This is issue number #19  and #20 